### PR TITLE
fix go run cmd

### DIFF
--- a/exercises/farewell-workflow/practice/microservice/README.md
+++ b/exercises/farewell-workflow/practice/microservice/README.md
@@ -7,7 +7,7 @@ and returns a greeting in Spanish customized for that name.
 Run the service:
 
 ```
-$ go run greeting-service.go
+$ go run greeting-and-farewell-service.go
 ```
 
 On a Mac, you might be prompted by the OS as to whether to allow incoming connections, so approve them if so.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated `go run` command to correct filename in `README.md` for the farewell-workflow microservice. 

## Why?
<!-- Tell your future self why have you made these changes -->
The command was referencing the incorrect file name.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- verified correct file name to use.
- tested new command to ensure success.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No other updates needed.
