### PR TITLE
Add explicit persistent volumes to containers

### DIFF
--- a/temporal-server/docker-compose.yml
+++ b/temporal-server/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - temporal-network
     expose:
       - 9200
+    volumes:
+      - es-data:/var/lib/elasticsearch/data
   postgresql:
     container_name: temporal-postgresql
     environment:
@@ -25,6 +27,8 @@ services:
       - temporal-network
     expose:
       - 5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
   temporal:
     container_name: temporal
     depends_on:
@@ -75,3 +79,6 @@ networks:
   temporal-network:
     driver: bridge
     name: temporal-network
+volumes:
+  db-data:
+  es-data:

--- a/temporal-server/docker-compose.yml
+++ b/temporal-server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     expose:
       - 9200
     volumes:
-      - es-data:/var/lib/elasticsearch/data
+      - /var/lib/elasticsearch/data
   postgresql:
     container_name: temporal-postgresql
     environment:
@@ -28,7 +28,7 @@ services:
     expose:
       - 5432
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - /var/lib/postgresql/data
   temporal:
     container_name: temporal
     depends_on:
@@ -79,6 +79,3 @@ networks:
   temporal-network:
     driver: bridge
     name: temporal-network
-volumes:
-  db-data:
-  es-data:


### PR DESCRIPTION
## What was changed
Docker containers for Elasticsearch and databases are now explicitly specify named volumes.

## Why?
When Docker re-creates containers from images, Elasticsearch data is lost, because container re-creation deletes volumes not explicitly specified in `Dockerfile`. Container re-creation can happen for variety of reasons, for example when one changes `docker-compose.yml` definition to expose ports. 

Postgres or MySQL or Cassandra data isn't lost, because image definition for those contain explicit `VOLUME` [command](https://github.com/docker-library/postgres/blob/master/13/alpine/Dockerfile#L154), however moving it to docker-compose definition for clarity as well. 

So now under volumes tab in Docker Desktop, or in the volumes list under `docker volumes list` command, there is a named volume for data, such as `temporal_db-data` and `temporal_es-data`, as opposed to randomly named volume for database data and no volume for Elasticsearch data.

## Checklist
<!--- add/delete as needed --->

1. Closes - (no issue, ad-hoc find)

2. How was this tested:
  - before the change:
    - run 'docker compose up'
    - run some test workflows
    - verify they both present in Elasticsearch (`tctl workflow list`) as well as in the database (`tctl workflow show wf_id`)
    - stop server/containers, modify container definition in docker-compose file, e.g. by adding ports section
    - run `docker compose up` again and notice that container is `recreated`
    - verify that Elasticsearch data is lost, but database data is here

  - after the change:
    - same steps, but after container recreation, data is not lost.

3. Any docs updates needed?
 - presumably, this was not the most common scenario, otherwise it would've reported earlier. however it is also an assumed behavior - if database data is not lost, Elasticsearch shouldn't be either.
 - README file change is unrelated, but just keeping it up-to-date.
