### PR TITLE
refactor: remove deprecated ioutil from example files

### DIFF
--- a/app.go
+++ b/app.go
@@ -7,12 +7,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 )
 
 func main() {
-	content, err := ioutil.ReadFile("README.md")
+	content, err := os.ReadFile("README.md")
 
 	if err != nil {
 		log.Fatal(err)

--- a/demos/service-workflow/translate.go
+++ b/demos/service-workflow/translate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -19,7 +19,7 @@ func GreetInSpanish(ctx context.Context, name string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/exercises/farewell-workflow/practice/translate.go
+++ b/exercises/farewell-workflow/practice/translate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -31,7 +31,7 @@ func callService(stem string, name string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/exercises/farewell-workflow/solution/translate.go
+++ b/exercises/farewell-workflow/solution/translate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -30,7 +30,7 @@ func callService(stem string, name string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package os See [Reference](https://pkg.go.dev/io/ioutil)

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Usage of ioutil package was replaced by io and os package

## Why?
[ioutil](https://pkg.go.dev/io/ioutil) is deprecated since go 1.16.
