### PR TITLE
VLN-469: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a top-level permissions block granting only contents: read to limit the default GITHUB_TOKEN scope for the workflow steps.